### PR TITLE
Fix build on Cygwin

### DIFF
--- a/Java/Makefile.PL
+++ b/Java/Makefile.PL
@@ -113,10 +113,11 @@ if ($build_jni){
 
 		# Cygwin: create gcc-compatible library wrapper for jvm.dll
 		if ($^O eq 'cygwin') {
-			my $dll = File::Spec->catfile(Cwd::cwd, 'libjvm.dll.a') ;
-			print "Creating '$dll' for cygwin.\n\n" ;
-			system("/usr/bin/dlltool --input-def jvm.def --kill-at --dllname jvm.dll --output-lib '$dll'") 
-				and print "Error attempting to create '$dll'\n" ;
+			my $lib = File::Spec->catfile(Cwd::cwd, 'libjvm.dll.a') ;
+			my $dll = File::Spec->catfile($files->{$jvm_so}->{selected}, 'jvm.dll') ;
+			print "Creating '$lib' for cygwin.\n\n" ;
+			system("/usr/bin/dlltool --kill-at --dllname jvm.dll --output-lib '$lib' '$dll'") 
+				and print "Error attempting to create '$lib'\n" ;
 		}
 
 		print "Building with:\n" ;

--- a/Java/jvm.def
+++ b/Java/jvm.def
@@ -1,4 +1,0 @@
-EXPORTS
-JNI_CreateJavaVM@12
-JNI_GetDefaultJavaVMInitArgs@4
-JNI_GetCreatedJavaVMs@12


### PR DESCRIPTION
Cygwin will not have permission to write to the Java installation
directory on a modern Windows system.

Restore the Java/jvm.def file. Modify Java/Makefile.PL to build
libjvm.dll.a in the current directory and include that directory during
compilation.