### PR TITLE
Append to classpath not safe without separator

### DIFF
--- a/t/16_subclass.t
+++ b/t/16_subclass.t
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $ENV{CLASSPATH} .= "t/t16subclass.jar";
+  $ENV{CLASSPATH} = "t/t16subclass.jar";
 }
 
 use Inline Java => 'STUDY', STUDY => ['t16subclass'];


### PR DESCRIPTION
It is not safe to append a new path to the CLASSPATH environment variable without a path separator that is suitable for the platform. I could not think of a good/concise way to determine the appropriate path separator, but it should not be necessary to have anything remain in it, so changing from append to assignment.

This resolves the "Class t16subclass not found" outstanding issue.